### PR TITLE
Fixes test failures on non-us locales

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,7 +467,7 @@
                     <includes>
                         <include>**/*Test.java</include>
                     </includes>
-                    <argLine>-javaagent:${settings.localRepository}/org/aspectj/aspectjweaver/${aspectjVersion}/aspectjweaver-${aspectjVersion}.jar</argLine>
+                    <argLine>-javaagent:${settings.localRepository}/org/aspectj/aspectjweaver/${aspectjVersion}/aspectjweaver-${aspectjVersion}.jar -Duser.language=en -Duser.country=US</argLine>
                     <systemProperties>
                         <property>
                             <name>log4j.debug</name>


### PR DESCRIPTION
On non-us locales some tests fail because the number format does not match the expected results
Adding explicit setting of locale for Surefire plugin argline solves it