### PR TITLE
Protection against XSS in AbstractGraphingServlet

### DIFF
--- a/src/main/java/net/jperf/servlet/AbstractGraphingServlet.java
+++ b/src/main/java/net/jperf/servlet/AbstractGraphingServlet.java
@@ -152,7 +152,10 @@ public abstract class AbstractGraphingServlet extends HttpServlet {
 
         Map<String, StatisticsChartGenerator> retVal = new LinkedHashMap<String, StatisticsChartGenerator>();
         for (String graphName : graphsToDisplay) {
-            retVal.put(graphName, getGraphByName(graphName));
+            StatisticsChartGenerator chartGenerator = getGraphByName(graphName);
+            if (chartGenerator != null) {
+                retVal.put(graphName, chartGenerator);
+            }
         }
         return retVal;
     }


### PR DESCRIPTION
Fixes issue #8,
The method getGraphByName will return `null` if there's not graphing appender with the provided name, so this will protect against arbitrary inputs.